### PR TITLE
feat: add delete port mapping from report table

### DIFF
--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -230,6 +230,29 @@ export class DataService {
     return [portQty, Array.from(tcpPorts), Array.from(udpPorts)];
   }
 
+  // Delete a specific mapped port entry from a server
+  deleteMappedPort(serverId: string, mappedPort: MappedPorts): void {
+    this.mappedPorts.update(current => {
+      return current.map(pm => {
+        if (pm.id !== serverId) return pm;
+        const index = pm.mappedPorts.findIndex(mp =>
+          mp.targetServerName === mappedPort.targetServerName &&
+          mp.sourceService === mappedPort.sourceService &&
+          mp.targetService === mappedPort.targetService &&
+          mp.port === mappedPort.port &&
+          mp.protocol === mappedPort.protocol &&
+          mp.product === mappedPort.product
+        );
+        if (index === -1) return pm;
+        const updated = [...pm.mappedPorts];
+        updated.splice(index, 1);
+        return { ...pm, mappedPorts: updated };
+      });
+    });
+    this.recalculateServerMappedPorts();
+    this.recalculateMappedPorts();
+  }
+
   // Update the port mapping data by UUID
   updatePortMapping(portMapping: PortMapping): void {
     this.mappedPorts.update(current => {

--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -231,7 +231,8 @@ export class DataService {
   }
 
   // Delete a specific mapped port entry from a server
-  deleteMappedPort(serverId: string, mappedPort: MappedPorts): void {
+  deleteMappedPort(serverId: string, mappedPort: MappedPorts): boolean {
+    let deleted = false;
     this.mappedPorts.update(current => {
       return current.map(pm => {
         if (pm.id !== serverId) return pm;
@@ -244,13 +245,17 @@ export class DataService {
           mp.product === mappedPort.product
         );
         if (index === -1) return pm;
+        deleted = true;
         const updated = [...pm.mappedPorts];
         updated.splice(index, 1);
         return { ...pm, mappedPorts: updated };
       });
     });
-    this.recalculateServerMappedPorts();
-    this.recalculateMappedPorts();
+    if (deleted) {
+      this.recalculateServerMappedPorts();
+      this.recalculateMappedPorts();
+    }
+    return deleted;
   }
 
   // Update the port mapping data by UUID

--- a/src/app/report/report.component.html
+++ b/src/app/report/report.component.html
@@ -264,6 +264,7 @@
             class="button is-danger is-light is-small"
             (click)="deleteMapping(mapping)"
             title="Delete this port mapping"
+            aria-label="Delete port mapping"
           >
             <span class="icon is-small">
               <i class="fas fa-trash"></i>

--- a/src/app/report/report.component.html
+++ b/src/app/report/report.component.html
@@ -207,6 +207,7 @@
             <p-sortIcon field="protocol" />
           </div>
         </th>
+        <th style="width: 4rem; text-align: center;"></th>
       </tr>
       <tr>
         <th><input pInputText type="text" (input)="dt.filter($any($event.target).value, 'sourceServer', 'contains')" placeholder="Filter..." class="p-inputtext-sm" style="width: 100%;" /></th>
@@ -216,6 +217,7 @@
         <th><input pInputText type="text" (input)="dt.filter($any($event.target).value, 'targetService', 'contains')" placeholder="Filter..." class="p-inputtext-sm" style="width: 100%;" /></th>
         <th><input pInputText type="text" (input)="dt.filter($any($event.target).value, 'port', 'contains')" placeholder="Filter..." class="p-inputtext-sm" style="width: 100%;" /></th>
         <th><input pInputText type="text" (input)="dt.filter($any($event.target).value, 'protocol', 'contains')" placeholder="Filter..." class="p-inputtext-sm" style="width: 100%;" /></th>
+        <th></th>
       </tr>
     </ng-template>
 
@@ -245,7 +247,7 @@
           {{ mapping.targetService }}
         </td>
         <td class="td-center">
-          <code class="port-code port-code--lg">
+          <code class="port-code port-code--lg" title="{{ mapping.description }}">
             {{ mapping.port }}
           </code>
         </td>
@@ -257,12 +259,23 @@
             {{ mapping.protocol }}
           </span>
         </td>
+        <td class="td-center">
+          <button
+            class="button is-danger is-light is-small"
+            (click)="deleteMapping(mapping)"
+            title="Delete this port mapping"
+          >
+            <span class="icon is-small">
+              <i class="fas fa-trash"></i>
+            </span>
+          </button>
+        </td>
       </tr>
     </ng-template>
 
     <ng-template #emptymessage>
       <tr>
-        <td colspan="7">
+        <td colspan="8">
           <div class="has-text-centered p-6 empty-state" style="border: none;">
             <i class="fas fa-search fa-3x mb-3 icon-muted"></i>
             <h4 class="title is-6 text-muted">No Matching Results</h4>

--- a/src/app/report/report.component.spec.ts
+++ b/src/app/report/report.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { MessageService } from 'primeng/api';
+import { MessageService, ConfirmationService } from 'primeng/api';
 import { ReportComponent } from './report.component';
 
 describe('ReportComponent', () => {
@@ -10,7 +10,7 @@ describe('ReportComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ReportComponent],
-      providers: [MessageService, provideRouter([])],
+      providers: [MessageService, ConfirmationService, provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ReportComponent);

--- a/src/app/report/report.component.ts
+++ b/src/app/report/report.component.ts
@@ -54,6 +54,7 @@ export class ReportComponent implements OnInit {
       item.mappedPorts.forEach(target => {
         this.flatMappings.push({
           ...target,
+          sourceServerId: item.id,
           sourceServer: item.sourceServer
         });
       });
@@ -133,15 +134,23 @@ export class ReportComponent implements OnInit {
       rejectLabel: 'Cancel',
       acceptButtonStyleClass: 'p-button-danger',
       accept: () => {
-        this.dataService.deleteMappedPort(mapping.sourceServerId, mapping);
-        this.portMapping = this.dataService.mappedPorts();
-        this.buildFlatMappings();
-        this.buildStats();
-        this.messageService.add({
-          severity: 'success',
-          summary: 'Mapping Deleted',
-          detail: `Removed ${mapping.port} ${mapping.protocol} mapping from "${mapping.sourceServer}".`
-        });
+        const deleted = this.dataService.deleteMappedPort(mapping.sourceServerId, mapping);
+        if (deleted) {
+          this.portMapping = this.dataService.mappedPorts();
+          this.buildFlatMappings();
+          this.buildStats();
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Mapping Deleted',
+            detail: `Removed ${mapping.port} ${mapping.protocol} mapping from "${mapping.sourceServer}".`
+          });
+        } else {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Mapping Not Found',
+            detail: `No matching mapping found for ${mapping.port} ${mapping.protocol} on "${mapping.sourceServer}".`
+          });
+        }
       }
     });
   }

--- a/src/app/report/report.component.ts
+++ b/src/app/report/report.component.ts
@@ -6,6 +6,7 @@ import { PortMapping, MappedPorts } from '../services';
 import { DiagramComponent } from '../diagram/diagram.component';
 import { TableModule, Table } from 'primeng/table';
 import { InputText } from 'primeng/inputtext';
+import { MessageService, ConfirmationService } from 'primeng/api';
 
 interface FlatMapping extends MappedPorts {
   sourceServer: string;
@@ -35,7 +36,9 @@ export class ReportComponent implements OnInit {
   serverMappingCounts: Map<string, number> = new Map();
 
   constructor(
-    private dataService: DataService
+    private dataService: DataService,
+    private messageService: MessageService,
+    private confirmationService: ConfirmationService
   ) { }
 
   ngOnInit(): void {
@@ -119,6 +122,28 @@ export class ReportComponent implements OnInit {
   // Toggle between table and diagram view
   toggleView(mode: 'table' | 'diagram'): void {
     this.viewMode = mode;
+  }
+
+  // Delete a specific port mapping entry
+  deleteMapping(mapping: FlatMapping): void {
+    this.confirmationService.confirm({
+      header: 'Delete Port Mapping',
+      message: `Delete "${mapping.sourceService} → ${mapping.targetService}" (${mapping.port} ${mapping.protocol}) from ${mapping.sourceServer}?`,
+      acceptLabel: 'Delete',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-danger',
+      accept: () => {
+        this.dataService.deleteMappedPort(mapping.sourceServerId, mapping);
+        this.portMapping = this.dataService.mappedPorts();
+        this.buildFlatMappings();
+        this.buildStats();
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Mapping Deleted',
+          detail: `Removed ${mapping.port} ${mapping.protocol} mapping from "${mapping.sourceServer}".`
+        });
+      }
+    });
   }
 
 }


### PR DESCRIPTION
## Summary
- Adds a **delete button** (trash icon) column to the report DataTable, allowing individual port mappings to be removed directly
- Shows a **confirmation dialog** with mapping details before deletion
- Recalculates all port totals, aggregations, and stats after deletion
- Adds **port description tooltip** — hovering over a port value shows its description
- Adds `deleteMappedPort()` method to `DataService` for targeted removal by matching on all key fields

Closes #46

## Test plan
- [ ] Navigate to the report table — a new trash icon column appears on each row
- [ ] Click the delete button — confirmation dialog shows the mapping details
- [ ] Confirm deletion — row is removed, table stats update, toast notification appears
- [ ] Cancel deletion — no changes made
- [ ] Hover over a port value — description tooltip appears
- [ ] Delete multiple mappings — totals on dashboard reflect the changes after navigating back
- [ ] CSV export still works correctly after deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)